### PR TITLE
Added ignoring of *.md files for GH action

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -3,6 +3,8 @@ name: Checking docker image
 on:
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 


### PR DESCRIPTION
If PR will consist of only '*.md' files changes, then GH action won't be applied